### PR TITLE
Add support for cloning branch repo via JUPYTER_PRELOAD_REPOS

### DIFF
--- a/minimal-notebook/start-singleuser.sh
+++ b/minimal-notebook/start-singleuser.sh
@@ -28,6 +28,13 @@ fi
 
 if [ -n "${JUPYTER_PRELOAD_REPOS}" ]; then
     for repo in `echo ${JUPYTER_PRELOAD_REPOS} | tr ',' ' '`; do
+        # Check for the presence of "@branch" in the repo string
+        REPO_BRANCH=$(echo ${repo} | cut -s -d'@' -f2)
+        if [[ -n ${REPO_BRANCH} ]]; then
+          # Remove the branch from the repo string and convert REPO_BRANCH to git clone arg
+          repo=$(echo ${repo} | cut -d'@' -f1)
+          REPO_BRANCH="-b ${REPO_BRANCH}"
+        fi
         echo "Checking if repository $repo exists locally"
         REPO_DIR=$(basename ${repo})
         if [ -d "${REPO_DIR}" ]; then
@@ -35,7 +42,7 @@ if [ -n "${JUPYTER_PRELOAD_REPOS}" ]; then
             GIT_SSL_NO_VERIFY=true git pull --ff-only
             popd
         else
-            GIT_SSL_NO_VERIFY=true git clone ${repo} ${REPO_DIR}
+            GIT_SSL_NO_VERIFY=true git clone ${repo} ${REPO_DIR} ${REPO_BRANCH}
         fi
     done
 fi


### PR DESCRIPTION
Notebook pod env var "JUPYTER_PRELOAD_REPOS" can now specify a branch
based on format `https://<GIT_REPO_URL>@<GIT_BRANCH_NAME>`

You can test this PR by building this notebook and pushing to a image registry for use

```
$ s2i build minimal-notebook registry.access.redhat.com/ubi7/python-36 test-jupyter-notebook:test
$ docker tag test-jupyter-notebook:test <Public Image Registry>:test-tag
$ docker push <Public Image Registry>:test-tag
```

Test the notebook by creating the env var below in the notebook and confirming that the respective repos were cloned with the correct branches.
```
JUPYTER_PRELOAD_REPOS=https://gitlab.com/opendatahub/data-engineering-and-machine-learning-workshop.git,https://github.com/vpavlin/jupyter-notebooks.git@spark-2.4
```